### PR TITLE
Force composer update for starter-kit-addon alongside monitoring-client

### DIFF
--- a/.github/workflows/job-deploy.yml
+++ b/.github/workflows/job-deploy.yml
@@ -63,7 +63,7 @@ jobs:
           export CURRENT_UID=$(id -u)
           export CURRENT_GID=$(id -g)
           source .env
-          docker compose -f docker-compose.build.yml run --rm composer su -c "composer update 'solidbunch/monitoring-client' --no-interaction --with-all-dependencies" "${DEFAULT_USER}"
+          docker compose -f docker-compose.build.yml run --rm composer su -c "composer update 'solidbunch/monitoring-client' 'solidbunch/starter-kit-addon' --no-interaction --with-all-dependencies" "${DEFAULT_USER}"
           bash ./sh/system/install.sh yes
 
       - name: Build Cache - save


### PR DESCRIPTION
Lock file entries for licensed metapackages stay pinned to whatever was resolved at lock time (stub or real dist). starter-kit-addon needs the same forced update as monitoring-client to pick up real dist content instead of the unlicensed metapackage stub.